### PR TITLE
Fix typo in footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -90,7 +90,7 @@ const LayoutFooter = () => (
         {new Date().getFullYear()}
         ,
         <a href="http://www.apache.org/" target="_blank" rel="noreferrer">
-          &nbsp;The Apache Software Fountation
+          &nbsp;The Apache Software Foundation
         </a>
         , &nbsp;Licensed under the Apache
         <a href="https://www.apache.org/licenses/" target="_blank" rel="noreferrer">


### PR DESCRIPTION
Correct spelling is _Foundation_ (see also https://www.apache.org/)